### PR TITLE
Changed page title from EnLight to enLIGHT

### DIFF
--- a/app/public/index.html
+++ b/app/public/index.html
@@ -18,7 +18,7 @@
     <script src="https://apis.google.com/js/api.js"></script>
 
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <title>EnLight</title>
+    <title>enLIGHT</title>
   </head>
 
   <body>


### PR DESCRIPTION
### Why was this PR opened? ###
Changing the page title.

### What are the changes? ###
Page title is now enLIGHT instead of EnLight